### PR TITLE
调试webpack

### DIFF
--- a/webpack_test/package.json
+++ b/webpack_test/package.json
@@ -25,7 +25,7 @@
     "vue": "^2.6.12",
     "vue-loader": "^14.2.0",
     "vue-template-compiler": "^2.6.12",
-    "webpack": "^4.5.0",
+    "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   }

--- a/webpack_test/package.json
+++ b/webpack_test/package.json
@@ -23,7 +23,7 @@
     "less-loader": "^6.2.0",
     "style-loader": "^2.0.0",
     "vue": "^2.6.12",
-    "vue-loader": "^14.2.0",
+    "vue-loader": "^15.9.5",
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",

--- a/webpack_test/src/main.js
+++ b/webpack_test/src/main.js
@@ -1,9 +1,8 @@
-console.log(333333);
 // debugger;
 import Vue from "vue";
-console.log(Vue);
-// import app from "./app.vue";
+// console.log(Vue);
+import app from "./app.vue";
 
-// new Vue({
-//   render: (h) => h(app),
-// }).$mount("#app");
+new Vue({
+  render: (h) => h(app),
+}).$mount("#app");

--- a/webpack_test/webpack.config.js
+++ b/webpack_test/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require("path");
 var HtmlWebpackPlugin = require("html-webpack-plugin");
+const VueLoaderPlugin = require("vue-loader/lib/plugin-webpack4")
 
 module.exports = {
   entry: "./src/main.js",
@@ -11,6 +12,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: "./public/index.html",
     }),
+    new VueLoaderPlugin()
   ],
   module: {
     rules: [


### PR DESCRIPTION
报错是webpack的问题，更新至4.44.2就没有问题了

顺便在配置项中加上了 VueLoaderPlugin。
> 这个插件是必须的！ 它的职责是将你定义过的其它规则复制并应用到 .vue 文件里相应语言的块。例如，如果你有一条匹配 /\.js$/ 的规则，那么它会应用到 .vue 文件里的 <script> 块。

babel配置的话使用 `@babel/preset-env`即可，这是一个babel的插件集合，从而不需要一个一个地配置。可以参考一下[这里](https://zxffan.github.io/posts/378e5729.html#Babel%E7%9A%84%E6%9C%80%E4%BD%B3%E5%AE%9E%E8%B7%B5)